### PR TITLE
fix typo in CIS.conf

### DIFF
--- a/roles/secure/files/CIS.conf
+++ b/roles/secure/files/CIS.conf
@@ -1,4 +1,4 @@
-nstall cramfs /bin/true
+install cramfs /bin/true
 install freevxfs /bin/true
 install jffs2 /bin/true
 install hfs /bin/true


### PR DESCRIPTION
line 1 was 'nstall cramfs /bin/true' updated to 'install cramfs /bin/true'
